### PR TITLE
Osal and unit test fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
         run: |
           cmake -E make_directory ${{github.workspace}}/build
           cmake -B ${{github.workspace}}/build -S ${{github.workspace}} \
+             -DBUILD_TESTING=ON \
              -DCMAKE_BUILD_TYPE=$BUILD_TYPE
 
       - name: Build

--- a/.github/workflows/clang-analysis.yml
+++ b/.github/workflows/clang-analysis.yml
@@ -2,10 +2,10 @@ name: Clang
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: '23 13 * * 3'
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,10 +2,10 @@ name: CodeQL
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: '23 13 * * 3'
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,6 @@ cmake_minimum_required (VERSION 3.14)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/tools")
 project (IOLINKMASTER VERSION 0.1.0)
-include(CTest)
 
 # Set required standard level
 set (CMAKE_C_STANDARD 99)
@@ -27,12 +26,20 @@ set (CMAKE_CXX_STANDARD 11)
 set(CMAKE_C_OUTPUT_EXTENSION_REPLACE 1)
 set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
 
-# Options
+# Default to installing in build directory
+if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set(CMAKE_INSTALL_PREFIX ${IOLINKMASTER_BINARY_DIR}/install
+    CACHE PATH "Default install path" FORCE)
+endif()
+
+include(AddOsal)
 include(CMakeDependentOption)
+
+# Options
 
 option (BUILD_SHARED_LIBS "Build shared library" OFF)
 option (LOG_ENABLE "Enable logging" OFF)
-option (BUILD_TESTS "Build unit tests" OFF)
+option (BUILD_TESTING "Build unit tests" OFF)
 
 set(LOG_STATE_VALUES "ON;OFF")
 set(LOG_LEVEL_VALUES "DEBUG;INFO;WARNING;ERROR")
@@ -85,9 +92,10 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/${CMAKE_SYSTEM_NAME}.cmake)
 
 # Source paths
 add_subdirectory (src)
-if (${BUILD_TESTS})
+if (BUILD_TESTING)
+  include(CTest)
   add_subdirectory (test)
-endif (${BUILD_TESTS})
+endif (BUILD_TESTING)
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
   add_subdirectory (samples/ifm_sample_app)
 endif ()

--- a/cmake/Linux.cmake
+++ b/cmake/Linux.cmake
@@ -14,19 +14,11 @@
 #*******************************************************************/
 
 set(OSAL_SOURCES
-  ${IOLINKMASTER_SOURCE_DIR}/../osal/src/linux/osal.c
-  ${IOLINKMASTER_SOURCE_DIR}/../osal/src/linux/osal_log.c
   ${IOLINKMASTER_SOURCE_DIR}/iol_osal/linux/osal_drv.c
   ${IOLINKMASTER_SOURCE_DIR}/iol_osal/linux/osal_fileops.c
   )
 set(OSAL_INCLUDES
-  ${IOLINKMASTER_SOURCE_DIR}/../osal/include
-  ${IOLINKMASTER_SOURCE_DIR}/../osal/src/linux
   ${IOLINKMASTER_SOURCE_DIR}/iol_osal/include
-  )
-set(OSAL_LIBS
-  "pthread"
-  "rt"
   )
 
 set(GOOGLE_TEST_INDIVIDUAL TRUE)

--- a/cmake/rt-kernel.cmake
+++ b/cmake/rt-kernel.cmake
@@ -14,8 +14,6 @@
 #*******************************************************************/
 
 set(OSAL_INCLUDES
-  ${IOLINKMASTER_SOURCE_DIR}/../osal/include
-  ${IOLINKMASTER_SOURCE_DIR}/../osal/src/rt-kernel
   ${RTK}/include
   ${RTK}/include/kern
   ${RTK}/include/arch/${ARCH}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,7 +58,7 @@ generate_export_header(iolmaster
 
 include_directories(${OSAL_INCLUDES})
 
-target_link_libraries(iolmaster ${OSAL_LIBS})
+target_link_libraries(iolmaster osal)
 
 set_property(TARGET iolmaster PROPERTY POSITION_INDEPENDENT_CODE ON)
 

--- a/src/iolink_al.c
+++ b/src/iolink_al.c
@@ -14,6 +14,7 @@
  ********************************************************************/
 
 #ifdef UNIT_TEST
+#include "mocks.h"
 #define DL_ReadParam_req           mock_DL_ReadParam_req
 #define DL_WriteParam_req          mock_DL_WriteParam_req
 #define DL_ISDUTransport_req       mock_DL_ISDUTransport_req

--- a/src/iolink_cm.c
+++ b/src/iolink_cm.c
@@ -14,6 +14,7 @@
  ********************************************************************/
 
 #ifdef UNIT_TEST
+#include "mocks.h"
 #define iolink_fetch_avail_job     mock_iolink_fetch_avail_job
 #define iolink_fetch_avail_api_job mock_iolink_fetch_avail_api_job
 #define iolink_post_job            mock_iolink_post_job

--- a/src/iolink_ds.c
+++ b/src/iolink_ds.c
@@ -14,6 +14,7 @@
  ********************************************************************/
 
 #ifdef UNIT_TEST
+#include "mocks.h"
 #define iolink_fetch_avail_job mock_iolink_fetch_avail_job
 #define iolink_post_job        mock_iolink_post_job
 #define DS_Ready               mock_DS_Ready

--- a/src/iolink_main.c
+++ b/src/iolink_main.c
@@ -14,6 +14,7 @@
  ********************************************************************/
 
 #ifdef UNIT_TEST
+#include "mocks.h"
 #define iolink_pl_init mock_iolink_pl_init
 #endif /* UNIT_TEST */
 

--- a/src/iolink_ode.c
+++ b/src/iolink_ode.c
@@ -14,6 +14,7 @@
  ********************************************************************/
 
 #ifdef UNIT_TEST
+#include "mocks.h"
 #define AL_Read_req                mock_AL_Read_req
 #define AL_Write_req               mock_AL_Write_req
 #define iolink_post_job            mock_iolink_post_job

--- a/src/iolink_pde.c
+++ b/src/iolink_pde.c
@@ -14,6 +14,7 @@
  ********************************************************************/
 
 #ifdef UNIT_TEST
+#include "mocks.h"
 #define AL_Control_req             mock_AL_Control_req
 #define AL_GetInput_req            mock_AL_GetInput_req
 #define AL_GetInputOutput_req      mock_AL_GetInputOutput_req

--- a/src/iolink_sm.c
+++ b/src/iolink_sm.c
@@ -14,6 +14,7 @@
  ********************************************************************/
 
 #ifdef UNIT_TEST
+#include "mocks.h"
 #define DL_Write_req            mock_DL_Write_req
 #define DL_Read_req             mock_DL_Read_req
 #define DL_SetMode_req          mock_DL_SetMode_req

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,11 +15,6 @@
 
 include(AddGoogleTest)
 
-set(OSAL_UUT
-  ${IOLINKMASTER_SOURCE_DIR}/../osal/src/linux/osal.c
-  ${IOLINKMASTER_SOURCE_DIR}/../osal/src/linux/osal_log.c
-  )
-
 add_definitions(
   -DUNIT_TEST
   )
@@ -33,7 +28,6 @@ add_executable(iol_test
   ${IOLINKMASTER_SOURCE_DIR}/src/iolink_ds.c
   ${IOLINKMASTER_SOURCE_DIR}/src/iolink_ode.c
   ${IOLINKMASTER_SOURCE_DIR}/src/iolink_pde.c
-  ${OSAL_UUT}
 
   # Unit tests
   test_sm.cpp
@@ -53,5 +47,8 @@ add_executable(iol_test
   )
 
 include_directories(${OSAL_INCLUDES} .)
-target_link_libraries(iol_test PUBLIC ${OSAL_LIBS})
+target_link_libraries(iol_test PUBLIC osal)
 add_gtest(iol_test)
+
+# No need for gmock
+set(BUILD_GMOCK OFF CACHE BOOL "")

--- a/test/mocks.cpp
+++ b/test/mocks.cpp
@@ -80,7 +80,7 @@ void (*mock_iolink_al_write_cnf_cb) (
 void (*mock_iolink_al_read_cnf_cb) (
    iolink_port_t * port,
    uint8_t len,
-   uint8_t * data,
+   const uint8_t * data,
    iolink_smi_errortypes_t errortype);
 
 uint8_t mock_iolink_smi_cnf_cnt            = 0;
@@ -264,8 +264,7 @@ iolink_error_t mock_DL_WriteParam_req (
 
 iolink_error_t mock_DL_Control_req (
    iolink_port_t * port,
-   iolink_controlcode_t controlcode,
-   void (*dl_control_cnf_cb) (iolink_port_t * port))
+   iolink_controlcode_t controlcode)
 {
    mock_iolink_dl_control_req_cnt++;
 
@@ -297,7 +296,7 @@ iolink_error_t mock_AL_Read_req (
    void (*al_read_cnf_cb) (
       iolink_port_t * port,
       uint8_t len,
-      uint8_t * data,
+      const uint8_t * data,
       iolink_smi_errortypes_t errortype))
 {
    mock_iolink_al_read_cnf_cb = al_read_cnf_cb;
@@ -378,18 +377,8 @@ iolink_error_t mock_AL_Control_ind (
 
 iolink_error_t mock_AL_SetOutput_req (
    iolink_port_t * port,
-   uint8_t len,
    uint8_t * data)
 {
-   if (len <= sizeof (mock_iolink_dl_pdout_data))
-   {
-      mock_iolink_dl_pdout_data_len = len;
-      memcpy (mock_iolink_dl_pdout_data, data, len);
-   }
-   else
-   {
-      CC_ASSERT (0);
-   }
    mock_iolink_al_setoutput_req_cnt++;
 
    return IOLINK_ERROR_NONE;
@@ -447,19 +436,8 @@ iolink_error_t mock_AL_NewInput_ind (iolink_port_t * port)
 
 iolink_error_t mock_DL_PDOutputUpdate_req (
    iolink_port_t * port,
-   uint8_t len,
    uint8_t * outputdata)
 {
-   if (len <= sizeof (mock_iolink_dl_pdout_data))
-   {
-      mock_iolink_dl_pdout_data_len = len;
-      memcpy (mock_iolink_dl_pdout_data, outputdata, len);
-   }
-   else
-   {
-      CC_ASSERT (0);
-   }
-
    return IOLINK_ERROR_NONE;
 }
 

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -24,7 +24,7 @@ extern "C" {
 #include "iolink_max14819.h"
 #include "osal.h"
 
-#include <cstddef>
+#include <stddef.h>
 #include <stdint.h>
 
 extern uint8_t mock_iolink_revisionid;
@@ -93,7 +93,7 @@ extern void (*mock_iolink_al_write_cnf_cb) (
 extern void (*mock_iolink_al_read_cnf_cb) (
    iolink_port_t * port,
    uint8_t len,
-   uint8_t * data,
+   const uint8_t * data,
    iolink_smi_errortypes_t errortype);
 
 iolink_error_t mock_DL_Write_req (
@@ -119,15 +119,13 @@ iolink_error_t mock_DL_ISDUTransport_req (
    iolink_isdu_vl_t * valuelist);
 iolink_error_t mock_DL_Control_req (
    iolink_port_t * port,
-   iolink_controlcode_t controlcode,
-   void (*dl_control_cnf_cb) (iolink_port_t * port));
+   iolink_controlcode_t controlcode);
 iolink_error_t mock_DL_PDOutputGet_req (
    iolink_port_t * port,
    uint8_t * len,
    uint8_t * data);
 iolink_error_t mock_DL_PDOutputUpdate_req (
    iolink_port_t * port,
-   uint8_t len,
    uint8_t * outputdata);
 iolink_error_t mock_DL_PDOutputUpdate (
    iolink_port_t * port,
@@ -140,7 +138,7 @@ iolink_error_t mock_AL_Read_req (
    void (*al_read_cnf_cb) (
       iolink_port_t * port,
       uint8_t len,
-      uint8_t * data,
+      const uint8_t * data,
       iolink_smi_errortypes_t errortype));
 void mock_AL_Read_cnf (
    iolink_port_t * port,
@@ -167,7 +165,6 @@ iolink_error_t mock_AL_Control_ind (
    iolink_controlcode_t controlcode);
 iolink_error_t mock_AL_SetOutput_req (
    iolink_port_t * port,
-   uint8_t len,
    uint8_t * data);
 iolink_error_t mock_AL_GetInputOutput_req (
    iolink_port_t * port,


### PR DESCRIPTION
Use AddOsal cmake module to pull in Osal. Fix mocking function prototypes and also a unit-test race condition.