### PR TITLE
Fix linking error in iolink_handler 

### DIFF
--- a/samples/ifm_sample_app/iolink_handler.c
+++ b/samples/ifm_sample_app/iolink_handler.c
@@ -42,6 +42,8 @@
       return 1;                                                                \
    }
 
+iolink_app_master_ctx_t iolink_app_master;
+
 static void SMI_cnf_cb (
    void * arg,
    uint8_t portnumber,

--- a/samples/ifm_sample_app/iolink_handler.h
+++ b/samples/ifm_sample_app/iolink_handler.h
@@ -114,7 +114,7 @@ typedef struct iolink_app_master_ctx
    uint32_t masterid;
 } iolink_app_master_ctx_t;
 
-iolink_app_master_ctx_t iolink_app_master;
+extern iolink_app_master_ctx_t iolink_app_master;
 
 void iolink_handler (iolink_m_cfg_t m_cfg);
 


### PR DESCRIPTION
Hi,

This commit fix linking error due to multiple declarations of iolink_app_master when including the header file.

I hope it will be useful for you.