### PR TITLE
Fix for deadlock in preoperate state

### DIFF
--- a/src/iolink_dl.c
+++ b/src/iolink_dl.c
@@ -419,8 +419,8 @@ static inline void iolink_dl_mode_h_sm_goto_operate (iolink_port_t * port)
    }
 
    MH_Conf (port, IOL_MHCMD_OPERATE);
-   DL_Mode_ind (port, IOLINK_MHMODE_OPERATE);
    dl->mode_handler.state = IOL_DL_MDH_ST_OPERATE_4;
+   DL_Mode_ind (port, IOLINK_MHMODE_OPERATE);
 }
 
 static void set_OH_IH_EH_Conf_active (iolink_port_t * port, bool active)
@@ -439,9 +439,9 @@ static inline void iolink_dl_mode_h_sm_goto_idle (
    set_OH_IH_EH_Conf_active (port, false);
    CH_Conf (port, IOL_CHCMD_INACTIVE);
    MH_Conf (port, IOL_MHCMD_INACTIVE);
-   DL_Mode_ind (port, mode);
    dl->mode_handler.mhinfo = IOLINK_MHINFO_NONE;
    dl->mode_handler.state  = IOL_DL_MDH_ST_IDLE_0;
+   DL_Mode_ind (port, mode);
 }
 
 static inline void iolink_dl_mode_h_sm_goto_startup (iolink_port_t * port)
@@ -450,8 +450,8 @@ static inline void iolink_dl_mode_h_sm_goto_startup (iolink_port_t * port)
 
    set_OH_IH_EH_Conf_active (port, false);
    MH_Conf (port, IOL_MHCMD_STARTUP);
-   DL_Mode_ind (port, IOLINK_MHMODE_STARTUP);
    dl->mode_handler.state = IOL_DL_MDH_ST_STARTUP_2;
+   DL_Mode_ind (port, IOLINK_MHMODE_STARTUP);
 }
 
 static void iolink_dl_mode_h_sm (iolink_port_t * port)
@@ -500,8 +500,8 @@ static void iolink_dl_mode_h_sm (iolink_port_t * port)
       {
          set_OH_IH_EH_Conf_active (port, true);
          MH_Conf (port, IOL_MHCMD_PREOPERATE);
-         DL_Mode_ind (port, IOLINK_MHMODE_PREOPERATE);
          dl->mode_handler.state = IOL_DL_MDH_ST_PREOPERATE_3;
+         DL_Mode_ind (port, IOLINK_MHMODE_PREOPERATE);
       }
       else if (dl->mode_handler.dl_mode == IOLINK_DLMODE_OPERATE) // T5
       {


### PR DESCRIPTION
Fixed deadlock after STARTUP_2 -> PREOPERATE_6 transition.

The stack would sometimes set two of the same event while only reading one, resulting in a deadlock after the tranisition STARTUP_2 -> PREOPERATE_6.

Changed MH_Conf so that it executes the message handler directly instead of setting an event, resulting in an instantaneous transition of the message handler.
Changed so that the internal state of the mode handler would change before indicating the state change to upper layers.